### PR TITLE
Revert the change to theme

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -116,7 +116,7 @@ rst_epilog = """
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
comment out the theme will make the build success using sphinx 7 version. But the generated html are not expected. So revert the change, and using sphinx 6.1.3 could pass build.