### PR TITLE
universal_payload.rst: Add ClockRate field to serial port info

### DIFF
--- a/source/2_universal_payload.rst
+++ b/source/2_universal_payload.rst
@@ -1145,6 +1145,7 @@ to payload.
     UINT8                            RegisterStride;
     UINT32                           BaudRate;
     EFI_PHYSICAL_ADDRESS             RegisterBase;
+    UINT32                           ClockRate;
   } UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO;
 
   #pragma pack()
@@ -1153,9 +1154,9 @@ to payload.
 
 ``Header``
 
-Header.Revision is 1.
+Header.Revision is 2.
 
-Header.Length is 18.
+Header.Length is 22.
 
 ``UseMmio``
 
@@ -1178,6 +1179,10 @@ Set to 0 to use the default baud rate 115200.
 ``RegisterBase``
 
 Base address of 16550 serial port registers in MMIO or I/O space.
+
+``ClockRate``
+
+The crystal or input frequency to the chip containing the UART.
 
 PCI Root Bridges
 %%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Add a ClockRate field to the UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO struct to allow the host firmware to pass the serial clock rate to the payload in order to properly initialize the serial/debug port.

This field is necessary because AMD Zen platform devices do not use the same clock rate as Intel devices.